### PR TITLE
Updated README.md with correct clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 To clone just the main branch:
 
 ```sh
-git clone -b master --single-branch git://github.com/sehugg/8bitworkshop.git
+git clone -b master --single-branch git@github.com:sehugg/8bitworkshop.git
 ```
 
 To build the 8bitworkshop IDE:


### PR DESCRIPTION
The original clone command using the endpoint 
`git://github.com/sehugg/8bitworkshop.git` did not work and has been replaced with a working one: `git@github.com:sehugg/8bitworkshop.git`

The original clone comand results in the following error:

```
git clone -b master --single-branch git://github.com/sehugg/8bitworkshop.git
Cloning into '8bitworkshop'...
fatal: unable to connect to github.com:
github.com[0: 140.82.121.3]: errno=Operation timed out
```

The new address was taken from the git repo page and appears to work fine.